### PR TITLE
Linkedlist iterator support

### DIFF
--- a/LinkedList.hpp
+++ b/LinkedList.hpp
@@ -16,6 +16,104 @@ public:
 	using pointer = T*;
 	using const_pointer = const T*;
 	
+	struct iterator {
+
+		Node* tnd{};	// Pointer to a node
+
+		reference operator*() {
+			return tnd->data;
+		}
+
+		pointer operator->() {
+			return &tnd->data;
+		}
+
+		// Prefix ++
+		iterator& operator++() {
+			tnd = tnd->next;
+			return *this;
+		}
+
+		// Postfix ++
+		iterator operator++(int) {
+			iterator old{ *this }; // Copy old state
+			tnd = tnd->next;
+			return old;	// Return the copy of the old state
+		}
+
+		// Prefix ==
+		iterator& operator--() {
+			tnd = tnd->prev;
+			return *this;
+		}
+
+		// Postfix ++
+		iterator operator==(int) {
+			iterator old{ *this };	// Save copy of the old iterator
+			tnd = tnd->prev;
+			return old;	// Return copy of the old iterator
+		}
+
+		// Comparison operators
+		bool operator==(const iterator& o) const { return tnd == o.tnd; }
+		bool operator!=(const iterator& o) const { return tnd != o.tnd; }
+
+	};
+
+	struct const_iterator {
+
+		const Node* tnd{};	// Pointer to a node
+
+		const_reference operator*() const {
+			return tnd->data;
+		}
+
+		const_pointer operator->() const {
+			return &tnd->data;
+		}
+
+		// Prefix ++
+		const_iterator& operator++() {
+			tnd = tnd->next;
+			return *this;
+		}
+
+		// Postfix ++
+		const_iterator operator++(int) {
+			iterator old{ *this }; // Copy old state
+			tnd = tnd->next;
+			return old;	// Return the copy of the old state
+		}
+
+		// Prefix ==
+		const_iterator& operator--() {
+			tnd = tnd->prev;
+			return *this;
+		}
+
+		// Postfix ++
+		const_iterator operator--(int) {
+			iterator old{ *this };	// Save copy of the old iterator
+			tnd = tnd->prev;
+			return old;	// Return copy of the old iterator
+		}
+
+		// Implicit conversion from non-const iterator
+		const_iterator(const iterator& other)
+			: tnd{ other.tnd }
+		{
+		}
+
+		// Comparison operators
+		bool operator==(const const_iterator& o) const { return tnd == o.tnd; }
+		bool operator!=(const const_iterator& o) const { return tnd != o.tnd; }
+
+	};
+
+
+
+
+
 	// Default Constructor
 	linkedlist() 
 	: m_head {nullptr}, m_tail {nullptr}, m_size {0}

--- a/LinkedList.hpp
+++ b/LinkedList.hpp
@@ -48,7 +48,7 @@ public:
 		}
 
 		// Postfix ++
-		iterator operator==(int) {
+		iterator operator--(int) {
 			iterator old{ *this };	// Save copy of the old iterator
 			tnd = tnd->prev;
 			return old;	// Return copy of the old iterator

--- a/LinkedList.hpp
+++ b/LinkedList.hpp
@@ -33,122 +33,6 @@ private:
 
 
 public:
-	struct iterator {
-
-		using value_type = linkedlist::value_type;
-		using size_type = linkedlist::size_type;
-		using difference_type = linkedlist::difference_type;
-		using reference = linkedlist::reference;
-		using const_reference = linkedlist::const_reference;;
-		using pointer = linkedlist::pointer;
-		using iterator_category = std::bidirectional_iterator_tag;
-
-
-		Node* tnd{};	// Pointer to a node
-
-		reference operator*() {
-			return tnd->data;
-		}
-
-		pointer operator->() {
-			return &tnd->data;
-		}
-
-		// Prefix ++
-		iterator& operator++() {
-			tnd = tnd->next;
-			return *this;
-		}
-
-		// Postfix ++
-		iterator operator++(int) {
-			iterator old{ *this }; // Copy old state
-			tnd = tnd->next;
-			return old;	// Return the copy of the old state
-		}
-
-		// Prefix ==
-		iterator& operator--() {
-			tnd = tnd->prev;
-			return *this;
-		}
-
-		// Postfix ++
-		iterator operator--(int) {
-			iterator old{ *this };	// Save copy of the old iterator
-			tnd = tnd->prev;
-			return old;	// Return copy of the old iterator
-		}
-
-		// Comparison operators
-		bool operator==(const iterator& o) const { return tnd == o.tnd; }
-		bool operator!=(const iterator& o) const { return tnd != o.tnd; }
-
-	};
-
-	struct const_iterator {
-
-		using value_type = linkedlist::value_type;
-		using size_type = linkedlist::size_type;
-		using difference_type = linkedlist::difference_type;
-		using reference = linkedlist::reference;
-		using const_reference = linkedlist::const_reference;;
-		using pointer = linkedlist::pointer;
-		using iterator_category = std::bidirectional_iterator_tag;
-
-		const Node* tnd{};	// Pointer to a node
-
-		const_reference operator*() const {
-			return tnd->data;
-		}
-
-		const_pointer operator->() const {
-			return &tnd->data;
-		}
-
-		// Prefix ++
-		const_iterator& operator++() {
-			tnd = tnd->next;
-			return *this;
-		}
-
-		// Postfix ++
-		const_iterator operator++(int) {
-			iterator old{ *this }; // Copy old state
-			tnd = tnd->next;
-			return old;	// Return the copy of the old state
-		}
-
-		// Prefix ==
-		const_iterator& operator--() {
-			tnd = tnd->prev;
-			return *this;
-		}
-
-		// Postfix ++
-		const_iterator operator--(int) {
-			iterator old{ *this };	// Save copy of the old iterator
-			tnd = tnd->prev;
-			return old;	// Return copy of the old iterator
-		}
-
-		// Implicit conversion from non-const iterator
-		const_iterator(const iterator& other)
-			: tnd{ other.tnd }
-		{
-		}
-
-		// Comparison operators
-		bool operator==(const const_iterator& o) const { return tnd == o.tnd; }
-		bool operator!=(const const_iterator& o) const { return tnd != o.tnd; }
-
-	};
-	
-	// Reverse iterators
-	using reverse_iterator = std::reverse_iterator<iterator>;
-	using const_reverse_iterator = std::reverse_iterator<const_iterator>;
-
-
 	// Default Constructor
 	linkedlist() 
 	: m_head {nullptr}, m_tail {nullptr}, m_size {0}
@@ -401,19 +285,146 @@ public:
 
 	}
 
-	// Function to print out a linkedlist just for testing
-	void print() const {
-		
-		std::cout << "{ ";
-		// Start at head and loop until last node
-		for (Node* tnd{ m_head }; tnd != nullptr; tnd = tnd->next) {
-			
-			// print the data at tnd
-			std::cout << tnd->data << " ";
+	
+	// =========================
+	// Iterators
+	// =========================
+
+	struct iterator {
+
+		using value_type = linkedlist::value_type;
+		using size_type = linkedlist::size_type;
+		using difference_type = linkedlist::difference_type;
+		using reference = linkedlist::reference;
+		using const_reference = linkedlist::const_reference;;
+		using pointer = linkedlist::pointer;
+		using iterator_category = std::bidirectional_iterator_tag;
+
+
+		Node* tnd{};	// Pointer to a node
+
+		reference operator*() {
+			return tnd->data;
 		}
 
-		std::cout << "}\n";
-	}
+		pointer operator->() {
+			return &tnd->data;
+		}
+
+		// Prefix ++
+		iterator& operator++() {
+			tnd = tnd->next;
+			return *this;
+		}
+
+		// Postfix ++
+		iterator operator++(int) {
+			iterator old{ *this }; // Copy old state
+			tnd = tnd->next;
+			return old;	// Return the copy of the old state
+		}
+
+		// Prefix ==
+		iterator& operator--() {
+			tnd = tnd->prev;
+			return *this;
+		}
+
+		// Postfix ++
+		iterator operator--(int) {
+			iterator old{ *this };	// Save copy of the old iterator
+			tnd = tnd->prev;
+			return old;	// Return copy of the old iterator
+		}
+
+		// Comparison operators
+		bool operator==(const iterator& o) const { return tnd == o.tnd; }
+		bool operator!=(const iterator& o) const { return tnd != o.tnd; }
+
+	};
+
+	struct const_iterator {
+
+		using value_type = linkedlist::value_type;
+		using size_type = linkedlist::size_type;
+		using difference_type = linkedlist::difference_type;
+		using reference = linkedlist::reference;
+		using const_reference = linkedlist::const_reference;;
+		using pointer = linkedlist::pointer;
+		using iterator_category = std::bidirectional_iterator_tag;
+
+		const Node* tnd{};	// Pointer to a node
+
+		const_reference operator*() const {
+			return tnd->data;
+		}
+
+		const_pointer operator->() const {
+			return &tnd->data;
+		}
+
+		// Prefix ++
+		const_iterator& operator++() {
+			tnd = tnd->next;
+			return *this;
+		}
+
+		// Postfix ++
+		const_iterator operator++(int) {
+			iterator old{ *this }; // Copy old state
+			tnd = tnd->next;
+			return old;	// Return the copy of the old state
+		}
+
+		// Prefix ==
+		const_iterator& operator--() {
+			tnd = tnd->prev;
+			return *this;
+		}
+
+		// Postfix ++
+		const_iterator operator--(int) {
+			iterator old{ *this };	// Save copy of the old iterator
+			tnd = tnd->prev;
+			return old;	// Return copy of the old iterator
+		}
+
+		// Implicit conversion from non-const iterator
+		const_iterator(const iterator& other)
+			: tnd{ other.tnd }
+		{
+		}
+
+		// Comparison operators
+		bool operator==(const const_iterator& o) const { return tnd == o.tnd; }
+		bool operator!=(const const_iterator& o) const { return tnd != o.tnd; }
+
+	};
+
+	// Reverse iterators
+	using reverse_iterator = std::reverse_iterator<iterator>;
+	using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+	// =========================
+	// Iterator Methods
+	// =========================
+
+	iterator begin() { return iterator{ m_head }; }
+	const_iterator begin() const {return iterator{m_head}; }
+	const_iterator cbegin() const { return const_iterator{ m_head }; }
+	
+	iterator end() { return iterator{ nullptr }; }	// Make end point to nullptr because that is the node after the tail	
+	const_iterator end() const { return iterator {nullptr}; }
+	const_iterator cend() const { return const_iterator{ nullptr }; }
+	
+	iterator rbegin() { return std::make_reverse_iterator(begin()); }
+	const_iterator rbegin() const { return std::make_reverse_iterator(cbegin()); }
+	const_iterator crbegin() const { return std::make_reverse_iterator(cbegin()); }
+	
+	iterator rend() { return std::make_reverse_iterator(end()); }
+	const_iterator rend() const { return std::make_reverse_iterator(cend()); }
+	const_iterator crend() const {return std::make_reverse_iterator(cend()); }
+	
 
 	// =========================
 	// Element Access

--- a/LinkedList.hpp
+++ b/LinkedList.hpp
@@ -2,11 +2,13 @@
 #include <iostream>
 #include <initializer_list>
 #include <memory>
+#include <iterator>
 
 namespace ReImplSTL
 {
 template <typename T>
 class linkedlist {
+
 public:
 	using value_type = T;
 	using size_type = std::size_t;
@@ -15,8 +17,32 @@ public:
 	using const_reference = const value_type&;
 	using pointer = T*;
 	using const_pointer = const T*;
-	
+
+
+private:
+	//  Inner Node Class
+	struct Node {
+		value_type data{};
+		Node* next{};	// pointer to the next node
+		Node* prev{}; // pointer to the previous node
+	};
+
+	Node* m_head{};
+	Node* m_tail{};
+	size_type m_size{};
+
+
+public:
 	struct iterator {
+
+		using value_type = linkedlist::value_type;
+		using size_type = linkedlist::size_type;
+		using difference_type = linkedlist::difference_type;
+		using reference = linkedlist::reference;
+		using const_reference = linkedlist::const_reference;;
+		using pointer = linkedlist::pointer;
+		using iterator_category = std::bidirectional_iterator_tag;
+
 
 		Node* tnd{};	// Pointer to a node
 
@@ -61,6 +87,14 @@ public:
 	};
 
 	struct const_iterator {
+
+		using value_type = linkedlist::value_type;
+		using size_type = linkedlist::size_type;
+		using difference_type = linkedlist::difference_type;
+		using reference = linkedlist::reference;
+		using const_reference = linkedlist::const_reference;;
+		using pointer = linkedlist::pointer;
+		using iterator_category = std::bidirectional_iterator_tag;
 
 		const Node* tnd{};	// Pointer to a node
 
@@ -109,9 +143,10 @@ public:
 		bool operator!=(const const_iterator& o) const { return tnd != o.tnd; }
 
 	};
-
-
-
+	
+	// Reverse iterators
+	using reverse_iterator = std::reverse_iterator<iterator>;
+	using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
 
 	// Default Constructor
@@ -749,18 +784,8 @@ public:
 	
 	
 
+// Helpers
 private:
-	//  Inner Node Class
-	struct Node {
-		value_type data {};
-		Node* next {};	// pointer to the next node
-		Node* prev {}; // pointer to the previous node
-	};
-
-	Node* m_head {};
-	Node* m_tail {};
-	size_type m_size {};
-
 	// Deallocates all the nodes in the linked list and leave the linkedlist in an empty state
 	void deallocate() {
 

--- a/ReImplSTL.cpp
+++ b/ReImplSTL.cpp
@@ -7,38 +7,25 @@
 #include "myVector.hpp"
 #include "LinkedList.hpp"
 
-
-
-template <typename T>
-void printVec(const ReImplSTL::vector<T>& vec)
-{
+template<typename T>
+void printList(const ReImplSTL::linkedlist<T>& list) {
+	
 	std::cout << "{ ";
-	for (int i{}; i < vec.size(); i++) {
-		std::cout << vec[i] << " ";
-	} 
-	std::cout << "}\n";
-}
-
-template <typename T>
-void iteratorTestPrintVec(const ReImplSTL::vector<T>& vec)
-{
-	std::cout << "{ ";
-	auto it = vec.cbegin();
-	for (;it != vec.cend(); ++it) {
-		std::cout << *it << " ";
+	for (auto it{ list.begin() }; it != list.end(); ++it) {
+		std::cout << *it << ' ';
 	}
+	
 	std::cout << "}\n";
 }
-
 
 
 int main()
 {
 	ReImplSTL::linkedlist<int> list {4, 2, 3, 4, 1, 1};
-	list.print();
+	printList(list);
 
 	list.resize(29, 222);
-	list.print();
+	printList(list);
 
 }
 


### PR DESCRIPTION
This pull request introduces a major enhancement to the `linkedlist` class in `LinkedList.hpp` by adding full iterator support, including forward, reverse, and const iterators. It also removes the old `print` method in favor of using iterators for traversal, and updates the test code in `ReImplSTL.cpp` to reflect these changes.

**Iterator support and usage improvements:**

* Added `iterator` and `const_iterator` nested classes to `linkedlist`, implementing bidirectional iterator functionality, including increment/decrement operators and comparison operators. Also added support for reverse iterators using `std::reverse_iterator`. (`LinkedList.hpp`)
* Implemented iterator access methods (`begin`, `end`, `rbegin`, `rend`, and their const/c-variants) in `linkedlist` to enable standard traversal patterns. (`LinkedList.hpp`)

**Code cleanup and refactoring:**

* Removed the old `print` method from `linkedlist`, as iteration is now handled via iterators. (`LinkedList.hpp`)
* Updated the test and utility code in `ReImplSTL.cpp` to use the new iterator-based `printList` function for printing the contents of a `linkedlist`. (`ReImplSTL.cpp`)

**Internal structure organization:**

* Moved the `Node` struct and related member variables to the private section of `linkedlist` for better encapsulation. (`LinkedList.hpp`) [[1]](diffhunk://#diff-420ab0e60af2309d2f5b633c9e3ef345daecc28b8acd24d918f2339de92ae849R21-R35) [[2]](diffhunk://#diff-420ab0e60af2309d2f5b633c9e3ef345daecc28b8acd24d918f2339de92ae849R798-L665)
* Added the `<iterator>` header to support iterator functionality. (`LinkedList.hpp`)